### PR TITLE
Post Controller has no admin-auth before filter

### DIFF
--- a/app/controllers/admin/PostsController.php
+++ b/app/controllers/admin/PostsController.php
@@ -18,6 +18,7 @@ class PostsController extends AdminController
 
       public function __construct(Post $post)
       {
+          parent::__construct();
           $this->post = $post;
       }
 


### PR DESCRIPTION
Admin\PostController override the AdminController contructor, so it does not inherits its precious admin-auth before filter